### PR TITLE
Fixes deprecation warning

### DIFF
--- a/lib/phoenix_sprite_sheet/worker.ex
+++ b/lib/phoenix_sprite_sheet/worker.ex
@@ -16,9 +16,8 @@ defmodule PhoenixSpriteSheet.Worker do
         FileSystem.subscribe(fs_pid)
         GenServer.cast(self(), :rebuild)
 
-
       other ->
-        Logger.warn(
+        Logger.warning(
           "PhoenixSpriteSheet could not start FileSystem. This is ok if you do are not using phoenix_live_reload."
         )
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhoenixSpriteSheet.MixProject do
   def project do
     [
       app: :phoenix_sprite_sheet,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
```
==> phoenix_sprite_sheet
Compiling 4 files (.ex)
warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
  lib/phoenix_sprite_sheet/worker.ex:21: PhoenixSpriteSheet.Worker.init/1
```